### PR TITLE
fix: remove six non-existent skill paths from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,18 +1,12 @@
-﻿{
+{
   "name": "nopua",
   "version": "2.0.0",
-  "description": "The anti-PUA. Drives AI with wisdom, trust, and inner motivation instead of fear and threats. Based on Dao De Jing philosophy. 7 languages, 7 platforms.",
+  "description": "The anti-PUA. Drives AI with wisdom, trust, and inner motivation instead of fear and threats. Based on Dao De Jing philosophy. 7 platforms.",
   "author": "WUJI (wuji-labs)",
   "homepage": "https://github.com/wuji-labs/nopua",
   "license": "MIT",
   "skills": [
-    { "name": "nopua", "path": "skills/nopua/SKILL.md", "language": "zh-CN" },
-    { "name": "nopua-en", "path": "skills/nopua-en/SKILL.md", "language": "en" },
-    { "name": "nopua-ja", "path": "skills/nopua-ja/SKILL.md", "language": "ja" },
-    { "name": "nopua-ko", "path": "skills/nopua-ko/SKILL.md", "language": "ko" },
-    { "name": "nopua-es", "path": "skills/nopua-es/SKILL.md", "language": "es" },
-    { "name": "nopua-pt", "path": "skills/nopua-pt/SKILL.md", "language": "pt" },
-    { "name": "nopua-fr", "path": "skills/nopua-fr/SKILL.md", "language": "fr" }
+    { "name": "nopua", "path": "skills/nopua/SKILL.md", "language": "zh-CN" }
   ],
   "agents": [
     { "name": "nopua-mentor", "path": "agents/nopua-mentor.md" }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugin.json` declares six skills with paths that do not exist in the repository:

- `skills/nopua-en/SKILL.md`
- `skills/nopua-ja/SKILL.md`
- `skills/nopua-ko/SKILL.md`
- `skills/nopua-es/SKILL.md`
- `skills/nopua-pt/SKILL.md`
- `skills/nopua-fr/SKILL.md`

Only `skills/nopua/`, `skills/nopua-lite/`, and `skills/nopua-zh/` exist. When a plugin loader resolves these paths at install time, it will fail to load six of the seven declared skills.

## Fix

Removed the six broken skill entries. The description's "7 languages" claim was also inaccurate and has been updated to remove it. The single registered skill (`skills/nopua/SKILL.md`) continues to work unchanged.

If the multilingual skill files are added in the future, these entries can be restored.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->