### PR TITLE
fix: correct language label for skills/nopua/SKILL.md and register nopua-zh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,8 @@
   "homepage": "https://github.com/wuji-labs/nopua",
   "license": "MIT",
   "skills": [
-    { "name": "nopua", "path": "skills/nopua/SKILL.md", "language": "zh-CN" },
+    { "name": "nopua", "path": "skills/nopua/SKILL.md", "language": "en" },
+    { "name": "nopua-zh", "path": "skills/nopua-zh/SKILL.md", "language": "zh-CN" },
     { "name": "nopua-en", "path": "skills/nopua-en/SKILL.md", "language": "en" },
     { "name": "nopua-ja", "path": "skills/nopua-ja/SKILL.md", "language": "ja" },
     { "name": "nopua-ko", "path": "skills/nopua-ko/SKILL.md", "language": "ko" },


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugin.json` registers `skills/nopua/SKILL.md` with `"language": "zh-CN"`, but the file contains English content — its title is `# NoPUA — Wisdom Over Whips` and all prose is English. As a result, users who request the `zh-CN` skill variant receive English content instead.

The actual zh-CN content lives at `skills/nopua-zh/SKILL.md`, which was entirely absent from the skills registration.

## Fix

Two minimal changes to `plugin.json`:

1. Changed `skills/nopua/SKILL.md` language tag from `"zh-CN"` to `"en"` to match its content.
2. Added `skills/nopua-zh/SKILL.md` with `"language": "zh-CN"` so the existing Chinese-language skill is properly discoverable.

No skill file content was modified — this is a registry-only correction.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->