### PR TITLE
fix: register nopua-mentor-en and nopua-mentor-ja in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,6 +15,8 @@
     { "name": "nopua-fr", "path": "skills/nopua-fr/SKILL.md", "language": "fr" }
   ],
   "agents": [
-    { "name": "nopua-mentor", "path": "agents/nopua-mentor.md" }
+    { "name": "nopua-mentor", "path": "agents/nopua-mentor.md" },
+    { "name": "nopua-mentor-en", "path": "agents/nopua-mentor-en.md" },
+    { "name": "nopua-mentor-ja", "path": "agents/nopua-mentor-ja.md" }
   ]
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`agents/nopua-mentor-en.md` and `agents/nopua-mentor-ja.md` exist in the repository with complete frontmatter — including `name`, `description`, `model`, and `tools` declarations — but neither is registered in `plugin.json`'s `agents` array. Only `nopua-mentor.md` (the default language version) appears there.

Because the plugin registry is the authoritative source of agent discoverability, the EN and JA mentor agents cannot be discovered or loaded by users who install the plugin.

## Fix

Added the two missing agent entries to the `agents` array in `plugin.json`. No agent file content was modified.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->